### PR TITLE
Refactored to use codename instead of id when rendering speaker details

### DIFF
--- a/kontent-sample-app-conference-net/Controllers/SpeakersController.cs
+++ b/kontent-sample-app-conference-net/Controllers/SpeakersController.cs
@@ -23,12 +23,12 @@ namespace kontent_sample_app_conference_net.Controllers
             return View(response.Items);
         }
 
-        public async Task<ActionResult> Detail(string id, string location)
+        public async Task<ActionResult> Detail(string codename, string location)
         {
             ViewBag.location = location;
 
             DeliveryItemListingResponse<Speaker> response = await DeliveryClient.GetItemsAsync<Speaker>(
-                new EqualsFilter("elements.speaker_id", id)
+                new EqualsFilter("system.codename", codename)
                 );
                 
             return View(response.Items[0]);

--- a/kontent-sample-app-conference-net/Startup.cs
+++ b/kontent-sample-app-conference-net/Startup.cs
@@ -55,7 +55,7 @@ namespace kontent_sample_app_conference_net
                 );
                 routes.MapRoute(
                     name: "speaker",
-                    template: "{location}/Speakers/{id}",
+                    template: "{location}/Speakers/{codename}",
                     defaults: new { controller = "Speakers", action = "Detail" }
                 );
 

--- a/kontent-sample-app-conference-net/Views/Speakers/Index.cshtml
+++ b/kontent-sample-app-conference-net/Views/Speakers/Index.cshtml
@@ -11,7 +11,7 @@
             @foreach (Speaker sp in Model)
             {
                 <div class="col-lg-3 col-md-6 col-xs-6">
-                    <a asp-route="speaker" asp-route-id="@sp.SpeakerId">
+                    <a asp-route="speaker" asp-route-codename="@sp.System.Codename">
                         <div class="speaker">
                             @if (sp.Photo.Any())
                             {


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #29 

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Try opening a speaker detail page.
